### PR TITLE
fix: support private GitHub repos for release downloads

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,5 +46,5 @@ export const AGENT_FOLDER_MAP: Record<string, string> = {
 
 export const CLAUDE_LOCAL_PATH = `${process.env.HOME}/.claude/local/claude`;
 
-export const REPO_OWNER = "github";
+export const REPO_OWNER = "berserkdisruptors";
 export const REPO_NAME = "buildforce-cli";

--- a/src/github.ts
+++ b/src/github.ts
@@ -31,9 +31,11 @@ export async function downloadTemplateFromGithub(
     skipTls = false,
   } = options;
 
+  const headers = getGithubAuthHeaders(githubToken);
+
   const client = axios.create({
     timeout: 30000,
-    headers: getGithubAuthHeaders(githubToken),
+    headers,
     httpsAgent: skipTls
       ? new (require("https").Agent)({ rejectUnauthorized: false })
       : undefined,
@@ -43,11 +45,12 @@ export async function downloadTemplateFromGithub(
     console.log(chalk.cyan("Fetching latest release information..."));
   }
 
-  const apiUrl = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest`;
-
+  // For private repos, /releases/latest may not work reliably
+  // Instead, fetch all releases and get the first non-draft, non-prerelease one
+  const apiUrl = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases`;
   let releaseData: ReleaseData;
   try {
-    const response = await client.get<ReleaseData>(apiUrl);
+    const response = await client.get<ReleaseData[]>(apiUrl);
 
     if (response.status !== 200) {
       let msg = `GitHub API returned ${response.status} for ${apiUrl}`;
@@ -62,7 +65,16 @@ export async function downloadTemplateFromGithub(
       throw new Error(msg);
     }
 
-    releaseData = response.data;
+    // Get the first release that is not a draft or prerelease
+    const latestRelease = response.data.find(
+      (release) => !release.draft && !release.prerelease
+    );
+
+    if (!latestRelease) {
+      throw new Error("No published releases found");
+    }
+
+    releaseData = latestRelease;
   } catch (e: any) {
     console.error(chalk.red("Error fetching release information"));
     console.error(e.message);
@@ -91,7 +103,8 @@ export async function downloadTemplateFromGithub(
     throw new Error("No matching release asset found");
   }
 
-  const downloadUrl = asset.browser_download_url;
+  // For private repos, use the API URL instead of browser_download_url
+  const downloadUrl = asset.url;
   const filename = asset.name;
   const fileSize = asset.size;
 
@@ -110,9 +123,14 @@ export async function downloadTemplateFromGithub(
   const spinner = showProgress ? ora("Downloading...").start() : null;
 
   try {
+    // For downloading release assets from private repos, we need to set Accept header
+    // to application/octet-stream
     const response = await client.get(downloadUrl, {
       responseType: "stream",
-      headers: getGithubAuthHeaders(githubToken),
+      headers: {
+        ...headers,
+        Accept: "application/octet-stream",
+      },
     });
 
     if (response.status !== 200) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,13 +24,16 @@ export interface ReleaseMetadata {
 
 export interface ReleaseAsset {
   name: string;
-  browser_download_url: string;
+  url: string; // API URL for downloading (requires auth for private repos)
+  browser_download_url: string; // Browser URL (doesn't work for private repos)
   size: number;
 }
 
 export interface ReleaseData {
   tag_name: string;
   assets: ReleaseAsset[];
+  draft: boolean;
+  prerelease: boolean;
 }
 
 export interface InitOptions {


### PR DESCRIPTION
This commit fixes the CLI to work with private GitHub repositories by:

1. Using GitHub API /releases endpoint instead of /releases/latest                                                                                       
 - /releases/latest returns 404 for private repos even with auth                                                                                       
 - Now fetches all releases and filters for the first non-draft, non-prerelease
 
2. Using asset.url (API endpoint) instead of browser_download_url                                                                                        
 - browser_download_url doesn't work for private repos                                                                                                
 - API endpoint requires Accept: application/octet-stream header
 
3. Adding required GitHub API headers to all requests                                                                                              
   - Accept: application/vnd.github+json                                                                                                           
   - X-GitHub-Api-Version: 2022-11-28                                                                                                              
   - Authorization: Bearer <token> (when provided)                                                                                                 
                                                                                                                                                   
4. Extended ReleaseData type with draft and prerelease properties                                                                                  
   - Needed to filter out draft/prerelease versions                                                                                                
                                                                                                                                                   
TODO: When repo goes public, revert these changes:                                                                                                 
- Revert REPO_OWNER from "berserkdisruptors" to "github" in src/constants.ts                                                                       
- Consider switching back to /releases/latest endpoint (optional, current approach works for both)                                                 
- Consider using browser_download_url for public repos (optional, API URL works for both)     