### PR TITLE
refactor: revert to prefix-based command naming structure buildforce.[command].md

### DIFF
--- a/.buildforce/context/cli-architecture.yaml
+++ b/.buildforce/context/cli-architecture.yaml
@@ -3,7 +3,7 @@ name: Buildforce CLI Architecture
 type: module
 status: production
 created: 2025-10-27
-last_updated: 2025-10-30
+last_updated: 2025-11-04
 
 summary: |
   Comprehensive architecture of the Buildforce CLI tool - a Node.js-based command-line
@@ -118,8 +118,8 @@ design_decisions:
   - decision: "Support local artifact resolution via --local flag"
     rationale: "Enables offline workflows, local testing during development, and faster iteration cycles. Developers can test locally-built artifacts without publishing to GitHub Releases."
 
-  - decision: "Nest BuildForce commands in buildforce/ subdirectory"
-    rationale: "Provides namespace isolation to prevent collision with user-defined custom commands. All 11 agents deploy commands to {agent-folder}/commands/buildforce/ (or prompts/buildforce/ for Copilot), improving discoverability and following common organizational patterns. Users can easily distinguish BuildForce commands from their own."
+  - decision: "Prefix BuildForce commands with buildforce. in flat directory"
+    rationale: "Provides namespace isolation without subdirectory nesting. All 11 agents deploy commands with buildforce. prefix (e.g., buildforce.spec.md) to {agent-folder}/commands/ (or prompts/ for Copilot). Flat structure simplifies discovery while preventing collision with user-defined commands. Dot notation in invocation (/buildforce.spec) is intuitive and widely recognized in CLI systems."
 
 architecture_patterns:
   entry_point: |
@@ -212,23 +212,24 @@ architecture_patterns:
 
   agent_configuration: |
     Supported Assistants (11+):
-    - Claude → .claude/commands/buildforce/
-    - Copilot → .github/prompts/buildforce/
-    - Cursor → .cursor/commands/buildforce/
-    - Gemini → .gemini/commands/buildforce/
-    - Qwen → .qwen/commands/buildforce/
-    - Windsurf → .windsurf/workflows/buildforce/
-    - Kilocode → .kilocode/workflows/buildforce/
-    - Auggie → .augment/commands/buildforce/
-    - Roo → .roo/commands/buildforce/
-    - OpenCode → .opencode/command/buildforce/
-    - Codex → .codex/prompts/buildforce/
+    - Claude → .claude/commands/buildforce.*.md
+    - Copilot → .github/prompts/buildforce.*.prompt.md
+    - Cursor → .cursor/commands/buildforce.*.md
+    - Gemini → .gemini/commands/buildforce.*.toml
+    - Qwen → .qwen/commands/buildforce.*.toml
+    - Windsurf → .windsurf/workflows/buildforce.*.md
+    - Kilocode → .kilocode/workflows/buildforce.*.md
+    - Auggie → .augment/commands/buildforce.*.md
+    - Roo → .roo/commands/buildforce.*.md
+    - OpenCode → .opencode/command/buildforce.*.md
+    - Codex → .codex/prompts/buildforce.*.md
 
     Command Deployment Structure:
-    - All BuildForce commands nested in buildforce/ subdirectory
+    - All BuildForce commands use buildforce. prefix in flat directory
     - Format varies by agent: .md (Claude, Cursor), .toml (Gemini, Qwen), .prompt.md (Copilot)
-    - 6 slash commands deployed: research, spec, plan, build, complete, document
-    - Namespace isolation prevents collision with user-defined custom commands
+    - 5 slash commands deployed: research, spec, build, complete, document
+    - Namespace isolation via filename prefix prevents collision with user-defined commands
+    - Invocation pattern: /buildforce.spec, /buildforce.research, /buildforce.build, etc.
 
     Detection Mechanism:
     - Uses which(tool) to find executables in PATH
@@ -344,8 +345,13 @@ evolution:
     date: "2025-10-30"
     changes: "Implemented nested command structure: all BuildForce commands now deploy to buildforce/ subdirectory within agent folders (e.g., .claude/commands/buildforce/). Modified generate_commands() function in create-release-packages.sh to create buildforce/ subdirectory and update output paths. Fixed validate_subset() return code bug. Verified across all 11 agents × 2 script variants (22 combinations)."
 
+  - version: "1.4"
+    date: "2025-11-04"
+    changes: "Reverted to prefix-based command naming: all BuildForce commands now use buildforce. prefix in flat directory structure (e.g., .claude/commands/buildforce.spec.md). Modified generate_commands() function to remove buildforce/ subdirectory creation and output commands with prefix-based naming (buildforce.$name.$ext). Updated all command template files to use /buildforce.* invocation pattern (dot notation instead of colon). Verified across all 11 agents × 2 script variants (22 combinations). Flat structure simplifies discovery while maintaining namespace isolation."
+
 related_specs:
   - nest-commands-buildforce-folder-20251030085832
+  - revert-to-prefix-naming-20251104000000
 
 notes: |
   Key architectural strengths:

--- a/.buildforce/specs/revert-to-prefix-naming-20251104000000/plan.yaml
+++ b/.buildforce/specs/revert-to-prefix-naming-20251104000000/plan.yaml
@@ -1,0 +1,421 @@
+# Plan Template for /build Agent Execution
+# This template is optimized for AI agent consumption during /build commands
+# It provides checkbox-based progress tracking, deviation logging, and spec traceability
+
+id: revert-to-prefix-naming-20251104000000-plan
+name: "Implementation Plan for Revert to Prefix-Based Command Naming"
+spec_id: "revert-to-prefix-naming-20251104000000"
+type: implementation-plan
+status: draft
+created: "2025-11-04"
+last_updated: "2025-11-04"
+
+# ARCHITECTURE OVERVIEW
+# Describe the high-level implementation approach and key technical decisions.
+
+approach: |
+  The implementation focuses on reverting the nested command structure to a flat prefix-based
+  approach. This involves modifying the generate_commands() function in create-release-packages.sh
+  to remove the buildforce/ subdirectory creation and update output paths to use buildforce.
+  prefix instead. All command template files will be updated to reference /buildforce.* invocation
+  pattern instead of /buildforce:*. Finally, context documentation will be updated to reflect the
+  new architecture decision.
+
+  The approach is:
+  1. Update generate_commands() function to output buildforce.$name.$ext instead of buildforce/$name.$ext
+  2. Update all command template files to use /buildforce.* invocation pattern
+  3. Update context documentation to reflect prefix-based naming
+  4. Test with local artifact generation (single agent + full matrix)
+  5. Verify ZIP contents and local initialization
+
+technology_stack:
+  - bash: "Shell scripting for create-release-packages.sh modifications"
+  - sed/awk: "Text processing for command template updates"
+  - zip: "Archive creation for release artifacts"
+
+decisions:
+  - decision: "Use buildforce. prefix instead of buildforce/ subdirectory"
+    rationale: "Achieves namespace isolation without requiring subdirectory support. Flat directory structure may be simpler for some agents while still preventing naming collisions. Dot notation is common in CLI and slash command systems."
+
+  - decision: "Modify generate_commands() mkdir and output paths only"
+    rationale: "Surgical change minimizes risk. The function is called for all agents, so modifying it once updates all 11 agents consistently. This reduces duplication and ensures consistency."
+
+  - decision: "Update command invocation pattern from /buildforce:* to /buildforce.*"
+    rationale: "Dot notation aligns with flat file prefix structure and is widely recognized across CLI systems. Provides clear association between command name and file name."
+
+  - decision: "Test with single agent before full matrix"
+    rationale: "Claude with bash is the most common configuration. Testing this first provides quick validation before running the full 22-variant matrix, saving time during development."
+
+# FILE STRUCTURE
+# List all files to be created or modified during implementation
+
+files_to_create: []
+
+files_to_modify:
+  - path: ".github/workflows/scripts/create-release-packages.sh"
+    change_type: "edit"
+    description: "Update generate_commands() function to remove buildforce/ subdirectory and use prefix-based naming"
+
+  - path: "src/templates/commands/research.md"
+    change_type: "edit"
+    description: "Change invocation references from /buildforce:research to /buildforce.research"
+
+  - path: "src/templates/commands/spec.md"
+    change_type: "edit"
+    description: "Change invocation references from /buildforce:spec to /buildforce.spec"
+
+  - path: "src/templates/commands/build.md"
+    change_type: "edit"
+    description: "Change invocation references from /buildforce:build to /buildforce.build"
+
+  - path: "src/templates/commands/complete.md"
+    change_type: "edit"
+    description: "Change invocation references from /buildforce:complete to /buildforce.complete"
+
+  - path: "src/templates/commands/document.md"
+    change_type: "edit"
+    description: "Change invocation references from /buildforce:document to /buildforce.document"
+
+  - path: ".buildforce/context/cli-architecture.yaml"
+    change_type: "edit"
+    description: "Update nested structure decision to reflect prefix-based naming approach"
+
+# IMPLEMENTATION PHASES
+# Break down the implementation into logical phases with checkbox-based task tracking
+# Use [ ] for pending tasks and [x] for completed tasks
+# Each task should link back to spec requirements via spec_refs
+
+phase_1:
+  name: "Update Command Generation Script"
+  description: |
+    Modify the generate_commands() function to remove buildforce/ subdirectory creation
+    and update output file paths to use buildforce. prefix instead of nested path.
+
+  tasks:
+    - [x] Update mkdir line from "mkdir -p \"$output_dir/buildforce\"" to "mkdir -p \"$output_dir\""
+      spec_refs: [FR1, FR2]
+      files: [.github/workflows/scripts/create-release-packages.sh]
+      notes: "Line ~42: Remove buildforce subdirectory creation"
+
+    - [x] Update toml output path from "$output_dir/buildforce/$name.$ext" to "$output_dir/buildforce.$name.$ext"
+      spec_refs: [FR1, FR3]
+      files: [.github/workflows/scripts/create-release-packages.sh]
+      notes: "Line ~77: Update toml case statement output path"
+
+    - [x] Update md output path from "$output_dir/buildforce/$name.$ext" to "$output_dir/buildforce.$name.$ext"
+      spec_refs: [FR1, FR3]
+      files: [.github/workflows/scripts/create-release-packages.sh]
+      notes: "Line ~79: Update md case statement output path"
+
+    - [x] Update prompt.md output path from "$output_dir/buildforce/$name.$ext" to "$output_dir/buildforce.$name.$ext"
+      spec_refs: [FR1, FR3]
+      files: [.github/workflows/scripts/create-release-packages.sh]
+      notes: "Line ~81: Update prompt.md case statement output path"
+
+  validation:
+    - [x] All phase_1 tasks completed
+    - [x] Script syntax is valid (no bash errors)
+    - [x] Changes affect only mkdir and output paths, not command content
+    - [x] Spec requirements covered: [FR1, FR2, FR3]
+
+phase_2:
+  name: "Update Command Template Invocation Patterns"
+  description: |
+    Update all command template files to reference /buildforce.* invocation pattern
+    instead of /buildforce:* pattern in user-facing text and examples.
+
+  tasks:
+    - [x] Update research.md to change /buildforce:research to /buildforce.research
+      spec_refs: [FR4]
+      files: [src/templates/commands/research.md]
+      notes: "Find and replace colon with dot in invocation references"
+
+    - [x] Update spec.md to change /buildforce:spec to /buildforce.spec
+      spec_refs: [FR4]
+      files: [src/templates/commands/spec.md]
+      notes: "Find and replace colon with dot in invocation references"
+
+    - [x] Update build.md to change /buildforce:build to /buildforce.build
+      spec_refs: [FR4]
+      files: [src/templates/commands/build.md]
+      notes: "Find and replace colon with dot in invocation references"
+
+    - [x] Update complete.md to change /buildforce:complete to /buildforce.complete
+      spec_refs: [FR4]
+      files: [src/templates/commands/complete.md]
+      notes: "Find and replace colon with dot in invocation references"
+
+    - [x] Update document.md to change /buildforce:document to /buildforce.document
+      spec_refs: [FR4]
+      files: [src/templates/commands/document.md]
+      notes: "Find and replace colon with dot in invocation references"
+
+  validation:
+    - [x] All phase_2 tasks completed
+    - [x] All command templates use /buildforce.* pattern consistently
+    - [x] No remaining /buildforce:* references in templates
+    - [x] Spec requirements covered: [FR4]
+
+phase_3:
+  name: "Test Single Agent Configuration"
+  description: |
+    Generate a single agent variant (claude + sh) locally to verify the prefix-based
+    structure is created correctly before running the full matrix.
+
+  tasks:
+    - [x] Run "AGENTS=claude SCRIPTS=sh .github/workflows/scripts/create-release-packages.sh v0.0.99"
+      spec_refs: [FR6, AC1]
+      files: []
+      notes: "Generates single ZIP in .genreleases/ directory"
+
+    - [x] Verify .genreleases/buildforce-cli-template-claude-sh-v0.0.99.zip exists
+      spec_refs: [FR6]
+      files: []
+      notes: "Confirms script completed without errors"
+
+    - [x] Unzip and inspect: unzip -l .genreleases/buildforce-cli-template-claude-sh-v0.0.99.zip | grep "buildforce\."
+      spec_refs: [FR1, FR7, AC1, AC4]
+      files: []
+      notes: "Verify commands use buildforce. prefix in flat directory"
+
+    - [x] Count command files: should have 5 files (research, spec, build, complete, document) with buildforce. prefix
+      spec_refs: [FR3, AC4]
+      files: []
+      notes: "Ensure all slash commands have prefix"
+
+    - [x] Verify no commands in buildforce/ subdirectory: unzip -l <zip> | grep "buildforce/"
+      spec_refs: [AC5]
+      files: []
+      notes: "Should return no results - confirms flat structure"
+
+  validation:
+    - [x] All phase_3 tasks completed
+    - [x] ZIP contains commands with buildforce. prefix in flat directory
+    - [x] No nested buildforce/ subdirectory exists
+    - [x] Spec requirements covered: [FR1, FR3, FR6, FR7]
+
+phase_4:
+  name: "Test Local Artifact Init"
+  description: |
+    Test the full init flow using local artifacts to verify extracted commands
+    are deployed to the correct flat prefix-based paths.
+
+  tasks:
+    - [x] Initialize test project: buildforce init test-prefix --local --ai claude --script sh
+      spec_refs: [FR7, AC3]
+      files: []
+      notes: "Uses locally generated ZIP from phase_3"
+
+    - [x] Verify commands at test-prefix/.claude/commands/buildforce.*.md (flat directory)
+      spec_refs: [FR1, FR7, AC3]
+      files: []
+      notes: "Check with: ls -la test-prefix/.claude/commands/"
+
+    - [x] Verify all 5 command files have buildforce. prefix
+      spec_refs: [FR3, AC4]
+      files: []
+      notes: "List: buildforce.research.md, buildforce.spec.md, buildforce.build.md, buildforce.complete.md, buildforce.document.md"
+
+    - [x] Verify no buildforce/ subdirectory exists
+      spec_refs: [AC5]
+      files: []
+      notes: "Check: ls test-prefix/.claude/commands/buildforce/ should fail"
+
+    - [x] Clean up test project: rm -rf test-prefix
+      spec_refs: []
+      files: []
+      notes: "Cleanup after verification"
+
+  validation:
+    - [x] All phase_4 tasks completed
+    - [x] Commands deployed with buildforce. prefix in flat directory
+    - [x] Init flow completes successfully
+    - [x] Spec requirements covered: [FR1, FR3, FR7]
+
+phase_5:
+  name: "Test Full Agent Matrix"
+  description: |
+    Run the full release package generation for all agents and script variants
+    to ensure consistency across all 22 combinations.
+
+  tasks:
+    - [x] Run full matrix: .github/workflows/scripts/create-release-packages.sh v0.0.99
+      spec_refs: [FR5, FR6, AC2]
+      files: []
+      notes: "Generates all 11 agents × 2 script types = 22 ZIP files"
+
+    - [x] Verify 22 ZIP files exist in .genreleases/
+      spec_refs: [FR6, AC2]
+      files: []
+      notes: "Check with: ls .genreleases/*.zip | wc -l"
+
+    - [x] Spot-check 3-4 different agent ZIPs for prefix-based structure
+      spec_refs: [FR5, AC2]
+      files: []
+      notes: "Test claude, gemini, copilot - different formats (.md, .toml, .prompt.md)"
+
+    - [x] Verify gemini uses .gemini/commands/buildforce.*.toml (flat with prefix)
+      spec_refs: [FR1, FR5]
+      files: []
+      notes: "Check TOML-based agents have correct flat prefix structure"
+
+    - [x] Verify copilot uses .github/prompts/buildforce.*.prompt.md (flat with prefix)
+      spec_refs: [FR1, FR5]
+      files: []
+      notes: "Check special-case agent folder (prompts vs commands)"
+
+    - [x] Run build pipeline smoke test: Check for script errors or warnings
+      spec_refs: [NFR2, AC6]
+      files: []
+      notes: "Review script output for any unexpected errors"
+
+  validation:
+    - [x] All phase_5 tasks completed
+    - [x] All 22 ZIP variants generated successfully
+    - [x] Prefix-based flat structure consistent across all agents
+    - [x] Spec requirements covered: [FR5, FR6, NFR2]
+
+phase_6:
+  name: "Update Context Documentation"
+  description: |
+    Update architecture documentation to reflect the reversion to prefix-based naming
+    and remove references to nested structure decision.
+
+  tasks:
+    - [x] Update cli-architecture.yaml to replace nested structure decision with prefix-based decision
+      spec_refs: []
+      files: [.buildforce/context/cli-architecture.yaml]
+      notes: "Lines 121-123: Update design_decisions section"
+
+    - [x] Update agent configuration section to show flat paths with buildforce. prefix
+      spec_refs: []
+      files: [.buildforce/context/cli-architecture.yaml]
+      notes: "Lines 215-225: Update example paths"
+
+    - [x] Update evolution section to document this reversion
+      spec_refs: []
+      files: [.buildforce/context/cli-architecture.yaml]
+      notes: "Add new version entry documenting prefix-based naming"
+
+    - [x] Add related_specs reference to this spec
+      spec_refs: []
+      files: [.buildforce/context/cli-architecture.yaml]
+      notes: "Link to revert-to-prefix-naming-20251104000000"
+
+  validation:
+    - [x] All phase_6 tasks completed
+    - [x] Documentation accurately reflects prefix-based naming
+    - [x] No remaining nested structure references
+    - [x] Evolution history updated
+
+# DEVIATION LOG
+# The /build agent populates this section when implementation deviates from the original plan
+# Format: phase → task → original plan → actual implementation → reason for deviation
+
+deviations: []
+
+# TESTING GUIDANCE
+# Structured guidance for testing the implementation
+
+testing:
+  automated_tests: []
+
+  manual_tests:
+    - scenario: "Verify single agent prefix-based deployment"
+      steps: |
+        1. Run: AGENTS=claude SCRIPTS=sh .github/workflows/scripts/create-release-packages.sh v0.0.99
+        2. Run: unzip -l .genreleases/buildforce-cli-template-claude-sh-v0.0.99.zip | grep "buildforce\."
+        3. Expected: 5 lines showing .claude/commands/buildforce.*.md files
+        4. Run: unzip -l .genreleases/buildforce-cli-template-claude-sh-v0.0.99.zip | grep "commands/buildforce/"
+        5. Expected: 0 lines (no nested subdirectory)
+
+    - scenario: "Verify local artifact init with prefix-based naming"
+      steps: |
+        1. Run: buildforce init test-prefix --local --ai claude --script sh
+        2. Run: ls -la test-prefix/.claude/commands/
+        3. Expected: 5 files with buildforce. prefix (buildforce.research.md, buildforce.spec.md, etc.)
+        4. Run: ls test-prefix/.claude/commands/buildforce/ 2>/dev/null
+        5. Expected: Error (directory doesn't exist - confirms flat structure)
+        6. Cleanup: rm -rf test-prefix
+
+    - scenario: "Verify multi-agent consistency"
+      steps: |
+        1. Run: .github/workflows/scripts/create-release-packages.sh v0.0.99
+        2. Run: for zip in .genreleases/*.zip; do echo "Checking $zip"; unzip -l "$zip" | grep -E "buildforce\." | head -3; done
+        3. Expected: Each ZIP shows commands with buildforce. prefix in flat directories
+        4. Verify different formats (.md for claude/cursor, .toml for gemini/qwen, .prompt.md for copilot)
+
+# VALIDATION CRITERIA
+# Define success metrics and track spec requirement coverage
+
+success_metrics:
+  - "All 22 ZIP variants contain commands with buildforce. prefix in flat directories"
+  - "No commands in nested buildforce/ subdirectory (flat structure only)"
+  - "Build pipeline completes with exit code 0"
+  - "Local init deploys commands with prefix-based naming"
+  - "All command templates reference /buildforce.* invocation pattern"
+
+spec_coverage:
+  - FR1: "✅ Phase 1: Tasks 1-4 (update mkdir and output paths)"
+  - FR2: "✅ Phase 1: Task 1 (remove subdirectory creation)"
+  - FR3: "✅ Phase 1: Tasks 2-4 (all 5 commands use buildforce. prefix)"
+  - FR4: "✅ Phase 2: Tasks 1-5 (update all template invocation patterns)"
+  - FR5: "✅ Phase 5: Tasks 1-5 (verify consistency across agents)"
+  - FR6: "✅ Phase 3: Task 1 + Phase 5: Task 1 (generate release packages)"
+  - FR7: "✅ Phase 4: Tasks 1-3 (local init verification)"
+  - NFR1: "✅ Implicit: No migration of existing projects"
+  - NFR2: "✅ Phase 5: Task 6 (build pipeline smoke test)"
+  - NFR3: "✅ Implicit: Flat structure equivalent or smaller"
+  - NFR4: "✅ Phase 1: Tasks 1-4 (simple path changes)"
+
+# PROGRESS SUMMARY
+# Track overall progress and identify next steps
+
+overall_progress:
+  phase_1: "4/4 tasks completed"
+  phase_2: "5/5 tasks completed"
+  phase_3: "5/5 tasks completed"
+  phase_4: "5/5 tasks completed"
+  phase_5: "6/6 tasks completed"
+  phase_6: "4/4 tasks completed"
+
+current_status: |
+  Implementation complete. All 6 phases successfully executed. Commands now use prefix-based
+  naming (buildforce.*) in flat directory structure. Verified across all 11 agents × 2 script
+  variants (22 combinations). Context documentation updated to reflect new architecture.
+
+next_immediate_steps:
+  - "All implementation complete - ready for PR or commit"
+  - "Consider testing with real workflow scenarios"
+  - "Monitor first release to ensure prefix-based naming works correctly across all agents"
+
+# RISKS & CONSIDERATIONS
+# Document potential risks and mitigation strategies
+
+risks:
+  - risk: "Agents may not recognize /buildforce.* invocation pattern"
+    mitigation: "Test with primary agents (Claude, Copilot, Cursor) first. Document any limitations. Dot notation is widely supported in CLI systems and should work across all agents."
+
+  - risk: "Existing projects initialized with nested structure may be confused by documentation changes"
+    mitigation: "Document in release notes that new projects use prefix-based naming. Old structure continues to work. Users can upgrade via 'buildforce upgrade' or reinitialize."
+
+  - risk: "Script errors during generation could produce invalid ZIPs"
+    mitigation: "Test incrementally with single agent first (phase 3). Verify ZIP contents before full matrix. Pipeline will catch errors."
+
+  - risk: "Special-case agents (copilot uses 'prompts' not 'commands') may need different validation"
+    mitigation: "Explicitly test copilot and other special cases in phase 5. Verify flat prefix structure works across all folder naming conventions."
+
+# NOTES
+# Capture lessons learned and future enhancement ideas
+
+lessons_learned:
+  - "Prefix-based naming provides namespace isolation without subdirectory complexity"
+  - "Dot notation is intuitive and widely recognized in CLI and slash command systems"
+  - "Testing with single agent before full matrix saves time during development"
+  - "Flat directory structure may be simpler for some agents and IDEs"
+
+future_enhancements:
+  - "Consider allowing users to customize command prefix via buildforce.json"
+  - "Add automated tests to CI/CD that verify command paths and naming in generated ZIPs"
+  - "Document command organization best practices for users adding custom commands"
+  - "Consider prefix-based naming for other buildforce assets (templates, scripts)"

--- a/.buildforce/specs/revert-to-prefix-naming-20251104000000/research.yml
+++ b/.buildforce/specs/revert-to-prefix-naming-20251104000000/research.yml
@@ -1,0 +1,175 @@
+id: "revert-to-prefix-naming-20251104000000-research"
+created: "2025-11-04"
+last_updated: "2025-11-04"
+
+summary: |
+  Research on slash command namespacing architecture in Buildforce CLI. Commit d34d931 (Oct 30, 2025)
+  introduced nested command structure (commands/buildforce/*.md) with colon-based invocation (/buildforce:spec).
+  Investigation identified the generate_commands() function in create-release-packages.sh as the key
+  implementation point, affecting all 11 agents across 22 release artifacts (agents × script types).
+
+key_findings:
+  - "Nested structure introduced in commit d34d931 on October 30, 2025 via spec nest-commands-buildforce-folder-20251030085832"
+  - "Commands currently deployed to {agent-folder}/commands/buildforce/ subdirectories across all 11 agents"
+  - "Invocation pattern uses colon separator (/buildforce:spec, /buildforce:research, etc.)"
+  - "5 core commands affected: research, spec, build, complete, document"
+  - "generate_commands() function (lines 40-84 in create-release-packages.sh) creates buildforce/ subdirectory and outputs to nested paths"
+  - "Command templates (src/templates/commands/*.md) reference /buildforce:* invocation pattern"
+  - "Before d34d931, commands used flat structure with no subdirectory nesting"
+
+file_paths:
+  primary:
+    - path: ".github/workflows/scripts/create-release-packages.sh"
+      relevance: "Core script implementing command generation with nested structure (lines 40-84)"
+    - path: "src/templates/commands/spec.md"
+      relevance: "Command template with /buildforce:spec invocation pattern"
+    - path: "src/templates/commands/research.md"
+      relevance: "Command template with /buildforce:research invocation pattern"
+    - path: "src/templates/commands/build.md"
+      relevance: "Command template with /buildforce:build invocation pattern"
+    - path: "src/templates/commands/complete.md"
+      relevance: "Command template with /buildforce:complete invocation pattern"
+    - path: "src/templates/commands/document.md"
+      relevance: "Command template with /buildforce:document invocation pattern"
+
+  secondary:
+    - path: ".buildforce/context/cli-architecture.yaml"
+      relevance: "Architecture documentation with nested structure decision (lines 121-123)"
+    - path: ".buildforce/context/slash-commands.yaml"
+      relevance: "Slash command system documentation"
+    - path: ".buildforce/specs/nest-commands-buildforce-folder-20251030085832/spec.yaml"
+      relevance: "Original spec documenting nested structure implementation"
+    - path: ".buildforce/specs/nest-commands-buildforce-folder-20251030085832/plan.yaml"
+      relevance: "Original implementation plan for nested structure"
+
+mermaid_diagrams:
+  - title: "Current Command Generation Flow (Nested Structure)"
+    description: "Shows how create-release-packages.sh generates nested command structure for different agents"
+    diagram: |
+      ```mermaid
+      graph TD
+          A[create-release-packages.sh] -->|generate_commands| B[Template Processing]
+          B --> C{Agent Type}
+
+          C -->|Claude| D[.claude/commands/buildforce/*.md]
+          C -->|Gemini| E[.gemini/commands/buildforce/*.toml]
+          C -->|Copilot| F[.github/prompts/buildforce/*.prompt.md]
+          C -->|Others| G[{agent}/commands/buildforce/*]
+
+          H[src/templates/commands/*.md] -->|Input| B
+          B -->|Replace Placeholders| I[${SCRIPT}, ${ARGUMENTS}, __AGENT__]
+
+          style D fill:#f9f,stroke:#333
+          style E fill:#f9f,stroke:#333
+          style F fill:#f9f,stroke:#333
+          style G fill:#f9f,stroke:#333
+      ```
+
+data_models:
+  - name: "Command"
+    description: "Data model representing a buildforce command in the generation system"
+    properties:
+      - name: "name"
+        type: "string"
+        required: true
+        description: "Command base name (e.g., 'spec', 'research', 'build')"
+
+      - name: "prefix"
+        type: "string"
+        required: true
+        description: "Namespace prefix ('buildforce')"
+
+      - name: "output_name"
+        type: "string"
+        required: true
+        description: "Final output filename (e.g., 'buildforce.spec.md' for prefix style or 'spec.md' for nested)"
+
+      - name: "agent"
+        type: "string"
+        required: true
+        description: "Target AI agent (claude, gemini, copilot, cursor, qwen, opencode, windsurf, codex, kilocode, auggie, roo)"
+
+      - name: "extension"
+        type: "enum"
+        required: true
+        description: "File extension: 'md' (Claude, Cursor, Windsurf, OpenCode, Kilocode, Auggie, Roo) | 'toml' (Gemini, Qwen) | 'prompt.md' (Copilot, Codex)"
+
+      - name: "output_dir"
+        type: "string"
+        required: true
+        description: "Output directory path (e.g., '.claude/commands' or '.github/prompts')"
+
+      - name: "arg_format"
+        type: "string"
+        required: true
+        description: "Argument placeholder format: '$ARGUMENTS' (md) or '{{args}}' (toml)"
+
+      - name: "script_variant"
+        type: "enum"
+        required: true
+        description: "'sh' (bash) or 'ps' (powershell)"
+
+    relationships:
+      - "Each Command maps to one agent and one script_variant combination"
+      - "Multiple Commands (11 agents × 2 scripts = 22 total) generated per release"
+      - "Commands reference template files in src/templates/commands/"
+
+code_snippets:
+  - title: "Current generate_commands() Function (Nested Structure)"
+    language: "bash"
+    description: "Shows current implementation that creates buildforce/ subdirectory"
+    code: |
+      generate_commands() {
+        local agent=$1 ext=$2 arg_format=$3 output_dir=$4 script_variant=$5
+        mkdir -p "$output_dir/buildforce"  # ← Creates nested subdirectory
+
+        # ... template processing ...
+
+        case $ext in
+          toml)
+            { echo "description = \"$description\""; echo; echo "prompt = \"\"\""; echo "$body"; echo "\"\"\""; } > "$output_dir/buildforce/$name.$ext" ;;  # ← Nested path
+          md)
+            echo "$body" > "$output_dir/buildforce/$name.$ext" ;;  # ← Nested path
+          prompt.md)
+            echo "$body" > "$output_dir/buildforce/$name.$ext" ;;  # ← Nested path
+        esac
+      }
+
+  - title: "Original generate_commands() Function (Flat Structure, Before d34d931)"
+    language: "bash"
+    description: "Shows pre-nested structure implementation with flat directory"
+    code: |
+      generate_commands() {
+        local agent=$1 ext=$2 arg_format=$3 output_dir=$4 script_variant=$5
+        mkdir -p "$output_dir"  # No subdirectory
+
+        # ... template processing ...
+
+        case $ext in
+          toml)
+            { echo "description = \"$description\""; echo; echo "prompt = \"\"\""; echo "$body"; echo "\"\"\""; } > "$output_dir/$name.$ext" ;;  # Flat structure
+          md)
+            echo "$body" > "$output_dir/$name.$ext" ;;  # Flat structure
+          prompt.md)
+            echo "$body" > "$output_dir/$name.$ext" ;;  # Flat structure
+        esac
+      }
+
+architectural_decisions:
+  - pattern: "Nested Command Structure (Current Implementation)"
+    description: "Commands deployed to {agent-folder}/commands/buildforce/ subdirectory with colon-based invocation"
+    rationale: "Provides namespace isolation to prevent collision with user-defined custom commands. Improves discoverability and follows common organizational patterns where tooling commands are grouped together."
+
+  - pattern: "Prefix-based Command Naming (Target Implementation)"
+    description: "Commands deployed to {agent-folder}/commands/ with buildforce. prefix (e.g., buildforce.spec.md) and dot-based invocation"
+    rationale: "Achieves namespace isolation without subdirectory nesting. Keeps flat directory structure while preventing naming collisions through file prefix. May be clearer for some agent systems that prefer flat command directories."
+
+external_references: []
+
+tldr:
+  - "Current state: Commands nested in buildforce/ subdirectory (e.g., .claude/commands/buildforce/spec.md), invoked as /buildforce:spec"
+  - "Desired state: Commands with buildforce. prefix in flat directory (e.g., .claude/commands/buildforce.spec.md), invoked as /buildforce.spec"
+  - "Key commit: d34d931 (Oct 30, 2025) introduced nested structure"
+  - "Files to modify: create-release-packages.sh (revert mkdir and output path), src/templates/commands/*.md (change invocation patterns from : to .)"
+  - "Scope: Affects all 11 agents × 2 script types = 22 release artifacts"
+  - "Related spec: nest-commands-buildforce-folder-20251030085832 documents the original nested structure implementation"

--- a/.buildforce/specs/revert-to-prefix-naming-20251104000000/spec.yaml
+++ b/.buildforce/specs/revert-to-prefix-naming-20251104000000/spec.yaml
@@ -1,0 +1,133 @@
+id: revert-to-prefix-naming-20251104000000
+name: "Revert to Prefix-Based Command Naming"
+type: feature
+status: draft
+created: "2025-11-04"
+last_updated: "2025-11-04"
+
+summary: |
+  Revert from nested command subdirectory structure (commands/buildforce/*.md) to prefix-based
+  flat naming (commands/buildforce.*.md) while maintaining namespace isolation. Commands will
+  use dot notation invocation (/buildforce.spec) instead of colon notation (/buildforce:spec).
+
+# INTENT / PROBLEM STATEMENT
+
+problem: |
+  Current nested structure (commands/buildforce/*.md) with colon-based invocation (/buildforce:spec)
+  requires subdirectory support from all agents. Some agents or IDEs may handle flat command directories
+  more naturally than nested subdirectories. The nested structure also adds an extra directory layer
+  that may not be necessary when prefix-based naming achieves the same namespace isolation goal.
+
+motivation: |
+  Prefix-based naming (buildforce.spec.md) provides equivalent namespace isolation in a flatter
+  directory structure. This approach may be simpler for agents that prefer or expect flat command
+  directories, while still clearly distinguishing BuildForce commands from user-defined commands.
+  The dot notation (/buildforce.spec) is also a common pattern in many CLI and slash command systems.
+
+# GOALS
+
+primary_goals:
+  - Revert command deployment from nested subdirectories to flat directories with buildforce. prefix
+  - Update command invocation pattern from colon notation (/buildforce:*) to dot notation (/buildforce.*)
+  - Maintain namespace isolation and prevent collisions with user-defined commands
+  - Ensure consistency across all 11 agents and 2 script variants (22 total artifacts)
+
+secondary_goals:
+  - Update context documentation to reflect prefix-based naming approach
+  - Verify local artifact resolution works with new naming pattern
+  - Test full release artifact generation pipeline
+
+# REQUIREMENTS
+
+functional_requirements:
+  - FR1: Commands MUST be deployed to {agent-folder}/commands/buildforce.*.{ext} instead of {agent-folder}/commands/buildforce/*.{ext}
+  - FR2: The generate_commands() function MUST create flat output directory without buildforce/ subdirectory
+  - FR3: All 5 slash commands (research, spec, build, complete, document) MUST use buildforce. prefix in filenames
+  - FR4: Command invocation pattern MUST change from /buildforce:* to /buildforce.* in all template files
+  - FR5: The deployment path structure MUST be consistent across all 11 supported agents
+  - FR6: Running create-release-packages.sh MUST produce ZIPs with correctly prefixed command files
+  - FR7: Extracted project templates MUST contain commands with buildforce. prefix after buildforce init
+
+non_functional_requirements:
+  - NFR1: Changes MUST NOT break existing projects already initialized with nested command structure
+  - NFR2: The build pipeline MUST complete successfully without errors
+  - NFR3: ZIP archive size MUST NOT increase (flat structure should be equivalent or smaller)
+  - NFR4: Command generation logic MUST remain maintainable and easy to understand
+
+# SCOPE
+
+in_scope:
+  - Modify generate_commands() function in create-release-packages.sh to remove buildforce/ subdirectory creation
+  - Update output file paths from "$output_dir/buildforce/$name.$ext" to "$output_dir/buildforce.$name.$ext"
+  - Update all command template files (src/templates/commands/*.md) to use /buildforce.* invocation pattern
+  - Update .buildforce/context/cli-architecture.yaml to reflect prefix-based naming decision
+  - Verify prefix-based structure in generated ZIP archives for all agent × script combinations
+  - Test local artifact resolution with new prefix-based naming
+
+out_of_scope:
+  - Migrating existing initialized projects to new command structure (users can upgrade or reinitialize)
+  - Changing command file content beyond invocation pattern references
+  - Modifying agent-specific command formats (.md, .toml, .prompt.md)
+  - Adding new commands or removing existing commands
+  - Changing the .buildforce/templates/ or .buildforce/scripts/ structure
+  - Updating existing release artifacts or GitHub releases (only affects future releases)
+
+# DESIGN PRINCIPLES
+
+design_principles:
+  - "Namespace isolation: BuildForce commands clearly separated via prefix, not subdirectory"
+  - "Consistency: All agents follow same flat structure with buildforce. prefix pattern"
+  - "Simplicity: Minimal code changes with maximum organizational benefit"
+  - "Backward compatibility: New projects use prefix naming, old projects continue working"
+  - "Clarity: Dot notation (/buildforce.spec) is intuitive and follows common CLI patterns"
+
+# ACCEPTANCE CRITERIA
+
+acceptance_criteria:
+  - AC1: Running "AGENTS=claude SCRIPTS=sh create-release-packages.sh v0.0.99" produces a ZIP with commands at .claude/commands/buildforce.*.md
+  - AC2: All 11 agents × 2 script variants (22 total combinations) have commands with buildforce. prefix in flat directories
+  - AC3: Unzipping a generated artifact and running "buildforce init --local" deploys commands to {agent}/commands/buildforce.*
+  - AC4: The 5 slash commands (research.md, spec.md, build.md, complete.md, document.md) have buildforce. prefix
+  - AC5: No commands remain in nested buildforce/ subdirectory (all use flat prefix pattern)
+  - AC6: Build pipeline completes without errors and produces valid ZIP archives
+  - AC7: All command template files reference /buildforce.* invocation pattern (not /buildforce:*)
+
+# ASSUMPTIONS & DEPENDENCIES
+
+assumptions:
+  - All agents support flat command directories with dot-prefixed filenames
+  - Users upgrading to new version will run "buildforce upgrade" or "buildforce init" to get new structure
+  - The generate_commands() function has write access to output_dir without subdirectory creation
+  - Dot notation in slash commands (/buildforce.spec) is recognized by all supported agents
+
+dependencies:
+  internal:
+    - create-release-packages.sh: "Core script that generates agent-specific command files"
+    - CLI init command: "Will extract commands to new flat prefix-based paths"
+    - CLI upgrade command: "Will update existing projects to new command structure"
+  external:
+    - bash: "4.0+ for script execution"
+    - zip: "For creating release archives"
+
+# OPEN QUESTIONS
+
+open_questions: []
+
+# NOTES
+
+notes: |
+  This change reverts the nested structure introduced in commit d34d931 (Oct 30, 2025) and
+  spec nest-commands-buildforce-folder-20251030085832. The reversion improves simplicity while
+  maintaining namespace isolation through filename prefixing.
+
+  The prefix-based structure results in paths like:
+  - .claude/commands/buildforce.research.md
+  - .gemini/commands/buildforce.research.toml
+  - .github/prompts/buildforce.research.prompt.md
+
+  Invocation patterns change from colon to dot:
+  - Old: /buildforce:spec, /buildforce:research, /buildforce:build
+  - New: /buildforce.spec, /buildforce.research, /buildforce.build
+
+  Testing strategy: Generate release packages locally, inspect ZIP contents, verify command paths
+  are correct, and test local artifact initialization before deployment.

--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -39,7 +39,7 @@ rewrite_paths() {
 
 generate_commands() {
   local agent=$1 ext=$2 arg_format=$3 output_dir=$4 script_variant=$5
-  mkdir -p "$output_dir/buildforce"
+  mkdir -p "$output_dir"
   for template in src/templates/commands/*.md; do
     [[ -f "$template" ]] || continue
     local name description script_command body
@@ -74,11 +74,11 @@ generate_commands() {
     
     case $ext in
       toml)
-        { echo "description = \"$description\""; echo; echo "prompt = \"\"\""; echo "$body"; echo "\"\"\""; } > "$output_dir/buildforce/$name.$ext" ;;
+        { echo "description = \"$description\""; echo; echo "prompt = \"\"\""; echo "$body"; echo "\"\"\""; } > "$output_dir/buildforce.$name.$ext" ;;
       md)
-        echo "$body" > "$output_dir/buildforce/$name.$ext" ;;
+        echo "$body" > "$output_dir/buildforce.$name.$ext" ;;
       prompt.md)
-        echo "$body" > "$output_dir/buildforce/$name.$ext" ;;
+        echo "$body" > "$output_dir/buildforce.$name.$ext" ;;
     esac
   done
 }

--- a/src/templates/commands/build.md
+++ b/src/templates/commands/build.md
@@ -38,6 +38,6 @@ $ARGUMENTS
 
 6. **Code Quality & Testing Guidance**: Before presenting work, verify: (1) code compiles with no errors, (2) run new or relevant automated tests and report results, (3) check for obvious missing pieces. Then provide testing guidance: **what to test** (specific features/scenarios), **how to test** (steps to verify), and **test results** (if automated tests ran). Think of this as submitting a PR—ensure nothing is obviously broken.
 
-7. **Iterative Refinement**: Expect multiple `/buildforce:build` iterations. Each time `/buildforce:build` is called, determine if this is the first implementation or a subsequent refinement based on $ARGUMENTS. Track deviations across all iterations. Ensure each iteration converges toward the user's desired outcome based on their feedback.
+7. **Iterative Refinement**: Expect multiple `/buildforce.build` iterations. Each time `/buildforce.build` is called, determine if this is the first implementation or a subsequent refinement based on $ARGUMENTS. Track deviations across all iterations. Ensure each iteration converges toward the user's desired outcome based on their feedback.
 
 Context: {$ARGUMENTS}

--- a/src/templates/commands/complete.md
+++ b/src/templates/commands/complete.md
@@ -18,7 +18,7 @@ $ARGUMENTS
    Check if there's an active spec to complete:
 
    - Read `.buildforce/buildforce.json` file from current working directory and parse the `currentSpec` field
-   - If file doesn't exist or `currentSpec` is null/empty: **ERROR** - Reply that there is no active spec and user must run `/buildforce:spec` first
+   - If file doesn't exist or `currentSpec` is null/empty: **ERROR** - Reply that there is no active spec and user must run `/buildforce.spec` first
    - If `currentSpec` field has a value (folder name): **PROCEED** - Extract folder name and continue
 
 2. **Load Spec Artifacts**:

--- a/src/templates/commands/document.md
+++ b/src/templates/commands/document.md
@@ -17,8 +17,8 @@ Before proceeding, verify sufficient context exists:
 
 - Check conversation history for file reads and substantive discussion about components, architecture, or patterns
 - If minimal context detected (0-2 file reads AND no substantive technical discussion):
-  - Respond: "I notice there's limited context in our conversation. Would you like to run `/buildforce:research [topic]` first to gather information about what you'd like to document?"
-  - Wait for user to either provide more context or run `/buildforce:research`
+  - Respond: "I notice there's limited context in our conversation. Would you like to run `/buildforce.research [topic]` first to gather information about what you'd like to document?"
+  - Wait for user to either provide more context or run `/buildforce.research`
 - If sufficient context exists, proceed with workflow below
 
 ## Workflow Steps

--- a/src/templates/commands/research.md
+++ b/src/templates/commands/research.md
@@ -17,7 +17,7 @@ $ARGUMENTS
 
 2. **Recency awareness**: If the query contains words like "current", "latest", "recent", "modern", "best practices", "2024", "2025", or "up-to-date", use web search to fetch current information—do not rely solely on training data.
 
-3. **Structured output**: Present findings as a report with clear sections (e.g., Research Summary, Project Context, Codebase Findings, External Knowledge, TLDR, Next Steps) that can be easily referenced in subsequent `/buildforce:spec`, `/buildforce:plan`, or `/buildforce:build` steps.
+3. **Structured output**: Present findings as a report with clear sections (e.g., Research Summary, Project Context, Codebase Findings, External Knowledge, TLDR, Next Steps) that can be easily referenced in subsequent `/buildforce.spec`, `/buildforce.plan`, or `/buildforce.build` steps.
 
 4. **Relevant file paths**: For codebase queries, provide an explicit table or list of all relevant file paths discovered. This saves time—users won't need to manually reference each file with @ in follow-up commands.
 

--- a/src/templates/commands/spec.md
+++ b/src/templates/commands/spec.md
@@ -12,7 +12,7 @@ User input:
 
 $ARGUMENTS
 
-The text the user typed after `/buildforce:spec` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `{ARGS}` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+The text the user typed after `/buildforce.spec` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `{ARGS}` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
 
 ## Workflow Steps
 
@@ -63,12 +63,12 @@ The text the user typed after `/buildforce:spec` in the triggering message **is*
 
    3. **Intelligent materialization from conversation** (CRITICAL - preserve information richness):
 
-      - **PRESERVE VERBATIM**: Mermaid diagrams, data models, code snippets - these are essential for /buildforce:build
+      - **PRESERVE VERBATIM**: Mermaid diagrams, data models, code snippets - these are essential for /buildforce.build
       - **PRESERVE WITH CONTEXT**: File paths (with relevance notes), architectural decisions (with rationale)
       - **CONDENSE INTELLIGENTLY**: Research summary prose (2-4 sentences), project context (key points only)
       - **MERGE**: TLDR bullets from research discussions into unified tldr section
       - **DO NOT TRUNCATE**: Diagrams, models, code snippets must be complete
-      - **DO NOT OVER-CONDENSE**: Preserve information-rich elements - /buildforce:build needs comprehensive context
+      - **DO NOT OVER-CONDENSE**: Preserve information-rich elements - /buildforce.build needs comprehensive context
 
    4. **Create research.yaml**:
       - Write to `.buildforce/specs/{FOLDER_NAME}/research.yaml`
@@ -312,8 +312,8 @@ The text the user typed after `/buildforce:spec` in the triggering message **is*
    **Risks:** [One sentence summary of main risks]
    ```
 
-   Then suggest: **"Ready to code? Run `/buildforce:build` to start implementation."**
+   Then suggest: **"Ready to code? Run `/buildforce.build` to start implementation."**
 
-   **For UPDATE mode**: Summarize changes made to spec.yaml and/or plan.yaml, present updated condensed plan summary if plan changed, and suggest: "Ready to code? Run `/buildforce:build` to start implementation."
+   **For UPDATE mode**: Summarize changes made to spec.yaml and/or plan.yaml, present updated condensed plan summary if plan changed, and suggest: "Ready to code? Run `/buildforce.build` to start implementation."
 
-   **IMPORTANT**: Every subsequent `/buildforce:spec` invocation updates BOTH files based on intelligent routing of the user's input content. Raw user input with explicit `/buildforce:spec` invocation might also intent to update BOTH so decide accordingly.
+   **IMPORTANT**: Every subsequent `/buildforce.spec` invocation updates BOTH files based on intelligent routing of the user's input content. Raw user input with explicit `/buildforce.spec` invocation might also intent to update BOTH so decide accordingly.


### PR DESCRIPTION
- Changed command deployment from a nested `buildforce/` subdirectory to a flat structure using the `buildforce.` prefix (e.g., `buildforce.spec.md`).
- Updated the `generate_commands()` function to remove the creation of the `buildforce/` subdirectory and adjust output paths accordingly.
- Modified command invocation patterns from colon-based (`/buildforce:spec`) to dot-based (`/buildforce.spec`) for improved clarity and consistency.
- Verified changes across all 11 agents and 2 script variants, ensuring consistent command deployment and updated context documentation to reflect the new architecture.