### PR TITLE
Fix: Getting project version

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { sessionCommand } from "./commands/session/index.js";
 import { generateBanner } from "./lib/interactive.js";
 import { MINT_COLOR, TAGLINE } from "./constants.js";
 import { createBox } from "./utils/box.js";
+import { getPackageVersion } from "./utils/package-info.js";
 
 const program = new Command();
 
@@ -17,7 +18,7 @@ program
   .name("buildforce")
   .usage("[command] [options]")
   .description(TAGLINE)
-  .version("1.0.0")
+  .version(getPackageVersion())
   .enablePositionalOptions();
 
 // --- Custom help formatting -------------------------------------------------

--- a/src/utils/package-info.ts
+++ b/src/utils/package-info.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+export function getPackageVersion(): string {
+    const fileName = fileURLToPath(import.meta.url);
+    const dirName = dirname(fileName);
+    const packageJsonPath = resolve(dirName, "../../package.json");
+    
+    const packageJsonContent = readFileSync(packageJsonPath, "utf-8");
+    const packageData = JSON.parse(packageJsonContent);
+
+    return packageData?.version ?? "0.0.0";
+}


### PR DESCRIPTION
This pull request is related to issue #52.  Instead hardcoded value, just check and getting version from the package.json file.

<img width="867" height="193" alt="Screenshot 2026-01-20 193458" src="https://github.com/user-attachments/assets/975b3840-e34e-461c-a3d9-62ebc2cc806a" />
